### PR TITLE
fixes and additions

### DIFF
--- a/Library/Device/Nuvoton/NUC1311/Include/system_NUC1311.h
+++ b/Library/Device/Nuvoton/NUC1311/Include/system_NUC1311.h
@@ -14,6 +14,8 @@
 #ifndef __SYSTEM_NUC1311_H
 #define __SYSTEM_NUC1311_H
 
+#include "stdint.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/Library/StdDriver/inc/clk.h
+++ b/Library/StdDriver/inc/clk.h
@@ -12,6 +12,8 @@
 #ifndef __CLK_H__
 #define __CLK_H__
 
+#include "NUC1311.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/Library/StdDriver/inc/gpio.h
+++ b/Library/StdDriver/inc/gpio.h
@@ -12,6 +12,8 @@
 #ifndef __GPIO_H__
 #define __GPIO_H__
 
+#include "NUC1311.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/Library/StdDriver/inc/pwm.h
+++ b/Library/StdDriver/inc/pwm.h
@@ -387,14 +387,14 @@ extern "C"
 /*---------------------------------------------------------------------------------------------------------*/
 /* Define PWM functions prototype                                                                          */
 /*---------------------------------------------------------------------------------------------------------*/
-uint32_t PWM_ConfigCaptureChannel(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32UnitTimeNsec, uint32_t u32CaptureEdge);
+uint32_t PWM_ConfigCaptureChannel(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32UnitTimeNsec);
 uint32_t PWM_ConfigOutputChannel(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32Frequency, uint32_t u32DutyCycle);
 void PWM_Start(PWM_T *pwm, uint32_t u32ChannelMask);
 void PWM_Stop(PWM_T *pwm, uint32_t u32ChannelMask);
 void PWM_ForceStop(PWM_T *pwm, uint32_t u32ChannelMask);
 void PWM_EnableADCTrigger(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32Condition);
 void PWM_DisableADCTrigger(PWM_T *pwm, uint32_t u32ChannelNum);
-void PWM_ClearADCTriggerFlag(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32Condition);
+void PWM_ClearADCTriggerFlag(PWM_T *pwm, uint32_t u32ChannelNum);
 uint32_t PWM_GetADCTriggerFlag(PWM_T *pwm, uint32_t u32ChannelNum);
 void PWM_EnableFaultBrake(PWM_T *pwm, uint32_t u32ChannelMask, uint32_t u32LevelMask, uint32_t u32BrakeSource);
 void PWM_EnableCapture(PWM_T *pwm, uint32_t u32ChannelMask);
@@ -417,7 +417,7 @@ void PWM_EnableFaultBrakeInt(PWM_T *pwm, uint32_t u32BrakeSource);
 void PWM_DisableFaultBrakeInt(PWM_T *pwm, uint32_t u32BrakeSource);
 void PWM_ClearFaultBrakeIntFlag(PWM_T *pwm, uint32_t u32BrakeSource);
 uint32_t PWM_GetFaultBrakeIntFlag(PWM_T *pwm, uint32_t u32BrakeSource);
-void PWM_EnablePeriodInt(PWM_T *pwm, uint32_t u32ChannelNum,  uint32_t u32IntPeriodType);
+void PWM_EnablePeriodInt(PWM_T *pwm, uint32_t u32ChannelNum);
 void PWM_DisablePeriodInt(PWM_T *pwm, uint32_t u32ChannelNum);
 void PWM_ClearPeriodIntFlag(PWM_T *pwm, uint32_t u32ChannelNum);
 uint32_t PWM_GetPeriodIntFlag(PWM_T *pwm, uint32_t u32ChannelNum);

--- a/Library/StdDriver/inc/pwm.h
+++ b/Library/StdDriver/inc/pwm.h
@@ -261,7 +261,15 @@ extern "C"
  * \hideinitializer
  */
 #define PWM_SET_CMR(pwm, u32ChannelNum, u32CMR) ((pwm)->CMPDAT[(u32ChannelNum)] = (u32CMR))
-
+/**
+ * @brief This macro set the duty cycle value of the selected PWM channel
+ * @param[in] pwm The pointer of the specified PWM module
+ * @param[in] u32ChannelNum PWM channel number. Valid values are between 0~5
+ * @param[in] u32Duty duty cycle value of specified PWM channel. Valid values are between 0~0xFFFF
+ * @return None
+ * @note Equivalent to the PWM_SET_CMR() macro. Created to improve understandability.
+ */
+#define PWM_SET_DUTY(pwm, u32ChannelNum, u32Duty) PWM_SET_CMR(pwm, u32ChannelNum, u32Duty)
 /**
  * @brief This macro set the period of the selected channel
  * @param[in] pwm The pointer of the specified PWM module
@@ -274,7 +282,15 @@ extern "C"
  * \hideinitializer
  */
 #define PWM_SET_CNR(pwm, u32ChannelNum, u32CNR)  ((pwm)->PERIOD[(((u32ChannelNum) >> 1) << 1)] = (u32CNR))
-
+/**
+ * @brief This macro set the period of the selected PWM channel
+ * @param[in] pwm The pointer of the specified PWM module
+ * @param[in] u32ChannelNum PWM channel number. Valid values are between 0~5
+ * @param[in] u32Period Period of specified PWM channel. Valid values are between 0~0xFFFF
+ * @return None
+ * @note Equivalent to the PWM_SET_CNR() macro. Created to improve understandability.
+ */
+#define PWM_SET_PERIOD(pwm, u32ChannelNum, u32Period) PWM_SET_CNR(pwm, u32ChannelNum, u32Period)
 /**
  * @brief This macro set the PWM aligned type
  * @param[in] pwm The pointer of the specified PWM module

--- a/Library/StdDriver/inc/pwm.h
+++ b/Library/StdDriver/inc/pwm.h
@@ -11,6 +11,8 @@
 #ifndef __PWM_H__
 #define __PWM_H__
 
+#include "NUC1311.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/Library/StdDriver/inc/spi.h
+++ b/Library/StdDriver/inc/spi.h
@@ -270,7 +270,7 @@ extern "C"
 
 /* Function prototype declaration */
 uint32_t SPI_Open(SPI_T *spi, uint32_t u32MasterSlave, uint32_t u32SPIMode, uint32_t u32DataWidth, uint32_t u32BusClock);
-void SPI_Close(SPI_T *spi);
+void SPI_Close(void);
 void SPI_ClearRxFIFO(SPI_T *spi);
 void SPI_ClearTxFIFO(SPI_T *spi);
 void SPI_DisableAutoSS(SPI_T *spi);

--- a/Library/StdDriver/inc/spi.h
+++ b/Library/StdDriver/inc/spi.h
@@ -12,6 +12,8 @@
 #ifndef __SPI_H__
 #define __SPI_H__
 
+#include "NUC1311.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/Library/StdDriver/inc/sys.h
+++ b/Library/StdDriver/inc/sys.h
@@ -12,6 +12,8 @@
 #ifndef __SYS_H__
 #define __SYS_H__
 
+#include "NUC1311.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/Library/StdDriver/inc/timer.h
+++ b/Library/StdDriver/inc/timer.h
@@ -11,6 +11,8 @@
 #ifndef __TIMER_H__
 #define __TIMER_H__
 
+#include "NUC1311.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/Library/StdDriver/inc/uart.h
+++ b/Library/StdDriver/inc/uart.h
@@ -12,6 +12,7 @@
 #ifndef __UART_H__
 #define __UART_H__
 
+#include "NUC1311.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/Library/StdDriver/inc/wdt.h
+++ b/Library/StdDriver/inc/wdt.h
@@ -11,6 +11,8 @@
 #ifndef __WDT_H__
 #define __WDT_H__
 
+#include "NUC1311.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/Library/StdDriver/inc/wwdt.h
+++ b/Library/StdDriver/inc/wwdt.h
@@ -11,6 +11,8 @@
 #ifndef __WWDT_H__
 #define __WWDT_H__
 
+#include "NUC1311.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/Library/StdDriver/src/can.c
+++ b/Library/StdDriver/src/can.c
@@ -69,19 +69,19 @@ static uint32_t GetFreeIF(CAN_T  *tCAN)
 static int can_update_spt(int sampl_pt, int tseg, int *tseg1, int *tseg2)
 {
     *tseg2 = tseg + 1 - (sampl_pt * (tseg + 1)) / 1000;
-    if (*tseg2 < TSEG2_MIN) {
-        *tseg2 = TSEG2_MIN;
+    if (*tseg2 < (int)TSEG2_MIN) {
+        *tseg2 = (int)TSEG2_MIN;
     } else {
     }
 
-    if (*tseg2 > TSEG2_MAX) {
-        *tseg2 = TSEG2_MAX;
+    if (*tseg2 > (int)TSEG2_MAX) {
+        *tseg2 = (int)TSEG2_MAX;
     } else {
     }
 
     *tseg1 = tseg - *tseg2;
-    if (*tseg1 > TSEG1_MAX) {
-        *tseg1 = TSEG1_MAX;
+    if (*tseg1 > (int)TSEG1_MAX) {
+        *tseg1 = (int)TSEG1_MAX;
         *tseg2 = tseg - *tseg1;
     } else {
     }
@@ -548,7 +548,7 @@ uint32_t CAN_SetBaudRate(CAN_T *tCAN, uint32_t u32BaudRate)
     int tsegall, tseg = 0, tseg1 = 0, tseg2 = 0;
     int spt_error = 1000, spt = 0, sampl_pt;
     uint64_t clock_freq = (uint64_t)0;
-    uint32_t sjw = (uint32_t)1;
+    int32_t sjw = 1;
 
     CAN_EnterInitMode(tCAN);
 
@@ -575,7 +575,7 @@ uint32_t CAN_SetBaudRate(CAN_T *tCAN, uint32_t u32BaudRate)
     }
 
     /* tseg even = round down, odd = round up */
-    for(tseg = (TSEG1_MAX + TSEG2_MAX) * 2ul + 1ul; tseg >= (TSEG1_MIN + TSEG2_MIN) * 2ul; tseg--)
+    for(tseg = (int)(TSEG1_MAX + TSEG2_MAX) * 2ul + 1ul; tseg >= (int)(TSEG1_MIN + TSEG2_MIN) * 2; tseg--)
     {
         tsegall = 1ul + tseg / 2ul;
         /* Compute all possible tseg choices (tseg=tseg1+tseg2) */
@@ -583,7 +583,7 @@ uint32_t CAN_SetBaudRate(CAN_T *tCAN, uint32_t u32BaudRate)
         /* chose brp step which is possible in system */
         brp = (brp / BRP_INC) * BRP_INC;
 
-        if((brp < BRP_MIN) || (brp > BRP_MAX))
+        if((brp < (int)BRP_MIN) || (brp > (int)BRP_MAX))
         {
             continue;
         }
@@ -628,9 +628,9 @@ uint32_t CAN_SetBaudRate(CAN_T *tCAN, uint32_t u32BaudRate)
 
     /* check for sjw user settings */
     /* bt->sjw is at least 1 -> sanitize upper bound to sjw_max */
-    if(sjw > SJW_MAX)
+    if(sjw > (int)SJW_MAX)
     {
-        sjw = SJW_MAX;
+        sjw = (int)SJW_MAX;
     }
     /* bt->sjw must not be higher than tseg2 */
     if(tseg2 < sjw)
@@ -642,7 +642,7 @@ uint32_t CAN_SetBaudRate(CAN_T *tCAN, uint32_t u32BaudRate)
     u32BaudRate = clock_freq / (best_brp * (tseg1 + tseg2 + 1));
 
     tCAN->BTIME = ((uint32_t)(tseg2 - 1ul) << CAN_BTIME_TSEG2_Pos) | ((uint32_t)(tseg1 - 1ul) << CAN_BTIME_TSEG1_Pos) |
-                  ((uint32_t)(best_brp - 1ul) & CAN_BTIME_BRP_Msk) | (sjw << CAN_BTIME_SJW_Pos);
+                  ((uint32_t)(best_brp - 1ul) & CAN_BTIME_BRP_Msk) | ((uint32_t)sjw << CAN_BTIME_SJW_Pos);
     tCAN->BRPE  = ((uint32_t)(best_brp - 1ul) >> 6) & 0x0Ful;
 
     /* printf("\n bitrate = %d \n", CAN_GetCANBitRate(tCAN)); */

--- a/Library/StdDriver/src/can.c
+++ b/Library/StdDriver/src/can.c
@@ -864,6 +864,37 @@ int32_t CAN_SetRxMsg(CAN_T *tCAN, uint32_t u32MsgNum , uint32_t u32IDType, uint3
 }
 
 /**
+  * @brief The function is used to configure a receive message object and mask.
+  *
+  * @param[in] tCAN The pointer to CAN module base address.
+  * @param[in] u32MsgNum Specifies the Message object number from 0 to 31.
+  * @param[in] u32IDType Specifies the identifier type of the frames that will be transmitted. Valid values are:
+  *                      - CAN_STD_ID: The 11-bit identifier.
+  *                      - CAN_EXT_ID: The 29-bit identifier.
+  * @param[in] u32ID Specifies the identifier used for acceptance filtering.
+  * @paran[in} u32IDMask The value to be used to mask the CAN ID.
+	*
+  * @retval FALSE No useful interface.
+  * @retval TRUE Configure a receive message object success.
+  *
+  * @details If the RxIE bit (CAN_IFn_MCON[10]) is set, the IntPnd bit (CAN_IFn_MCON[13])
+  *          will be set when a received Data Frame is accepted and stored in the Message Object.
+  */
+int32_t CAN_SetRxMsgAndMsk(CAN_T *tCAN, uint32_t u32MsgNum , uint32_t u32IDType, uint32_t u32ID, uint32_t u32IDMask)
+{
+		uint32_t u32TimeOutCount = 0;
+
+    while(CAN_SetRxMsgObjAndMsk(tCAN, u32MsgNum, u32IDType, u32ID, u32IDMask, TRUE) == FALSE)
+    {
+        u32TimeOutCount++;
+
+        if(u32TimeOutCount >= 0x10000000) return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
   * @brief The function is used to configure several receive message objects.
   *
   * @param[in] tCAN The pointer to CAN module base address.

--- a/Library/StdDriver/src/fmc.c
+++ b/Library/StdDriver/src/fmc.c
@@ -269,7 +269,7 @@ int32_t FMC_ReadConfig(uint32_t *u32Config, uint32_t u32Count)
   */
 int32_t FMC_WriteConfig(uint32_t *u32Config, uint32_t u32Count)
 {
-    int32_t i;
+    uint32_t i;
 
     g_FMC_i32ErrCode = 0;
 

--- a/Library/StdDriver/src/pwm.c
+++ b/Library/StdDriver/src/pwm.c
@@ -34,7 +34,7 @@
  * @return The nearest unit time in nano second.
  * @details This function is used to Configure PWM capture and get the nearest unit time.
  */
-uint32_t PWM_ConfigCaptureChannel(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32UnitTimeNsec, uint32_t u32CaptureEdge)
+uint32_t PWM_ConfigCaptureChannel(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32UnitTimeNsec)
 {
     uint32_t u32Src;
     uint32_t u32PWMClockSrc;
@@ -285,11 +285,10 @@ void PWM_DisableADCTrigger(PWM_T *pwm, uint32_t u32ChannelNum)
  *                - PWM0 : PWM Group 0
  *                - PWM1 : PWM Group 1
  * @param[in] u32ChannelNum PWM channel number. Valid values are between 0~5
- * @param[in] u32Condition This parameter is not used
  * @return None
  * @details This function is used to clear selected channel trigger ADC flag.
  */
-void PWM_ClearADCTriggerFlag(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32Condition)
+void PWM_ClearADCTriggerFlag(PWM_T *pwm, uint32_t u32ChannelNum)
 {
     (pwm)->STATUS = (PWM_STATUS_ADCTRGF0_Msk << u32ChannelNum);
 }
@@ -718,11 +717,10 @@ uint32_t PWM_GetFaultBrakeIntFlag(PWM_T *pwm, uint32_t u32BrakeSource)
  *                - PWM0 : PWM Group 0
  *                - PWM1 : PWM Group 1
  * @param[in] u32ChannelNum PWM channel number. Valid values are between 0~5. Every two channels share the same setting.
- * @param[in] u32IntPeriodType Period interrupt type. This parameter is not used.
  * @return None
  * @details This function is used to enable period interrupt of selected channel.
  */
-void PWM_EnablePeriodInt(PWM_T *pwm, uint32_t u32ChannelNum,  uint32_t u32IntPeriodType)
+void PWM_EnablePeriodInt(PWM_T *pwm, uint32_t u32ChannelNum)
 {
     (pwm)->INTEN0 |= (PWM_INTEN0_PIEN0_Msk << ((u32ChannelNum >> 1) << 1));
 }

--- a/Library/StdDriver/src/retarget.c
+++ b/Library/StdDriver/src/retarget.c
@@ -184,7 +184,7 @@ int32_t SH_Return(int32_t n32In_R0, int32_t n32In_R1, int32_t *pn32Out_R0)
 #endif
 #else // defined(DEBUG_ENABLE_SEMIHOST)
 
-int32_t SH_Return(int32_t n32In_R0, int32_t n32In_R1, int32_t *pn32Out_R0);
+int32_t SH_Return(void);
 
 #if defined( __ICCARM__ )
 __WEAK
@@ -226,9 +226,6 @@ uint32_t ProcessHardFault(uint32_t lr, uint32_t msp, uint32_t psp)
 #endif
 
     printf("  HardFault!\n\n");
-
-    /*
-    printf("  HardFault!\n\n");
     printf("r0  = 0x%x\n", sp[0]);
     printf("r1  = 0x%x\n", sp[1]);
     printf("r2  = 0x%x\n", sp[2]);
@@ -237,16 +234,15 @@ uint32_t ProcessHardFault(uint32_t lr, uint32_t msp, uint32_t psp)
     printf("lr  = 0x%x\n", sp[5]);
     printf("pc  = 0x%x\n", sp[6]);
     printf("psr = 0x%x\n", sp[7]);
-    */
 
     /* Or *sp to remove compiler warning */
-    while(1U|*sp){}
+    while(1){}
 
     return lr;
 }
 
 
-int32_t SH_Return(int32_t n32In_R0, int32_t n32In_R1, int32_t *pn32Out_R0)
+int32_t SH_Return(void)
 {
     return 0;
 }

--- a/Library/StdDriver/src/spi.c
+++ b/Library/StdDriver/src/spi.c
@@ -139,11 +139,10 @@ uint32_t SPI_Open(SPI_T *spi,
 
 /**
   * @brief  Disable SPI controller.
-  * @param[in]  spi The pointer of the specified SPI module.
   * @return None
   * @details This function will reset SPI controller.
   */
-void SPI_Close(SPI_T *spi)
+void SPI_Close(void)
 {
     /* Reset SPI */
     SYS->IPRSTC2 |= SYS_IPRSTC2_SPI0_RST_Msk;


### PR DESCRIPTION
* "stdint.h" and "NUC1311.h" libraries cannot be accessed because they are not called in the files. It is not reflected in the error counter when compiling in Keil, but it appears as an error in the file. Fixed.
* "Sign Compare", "Unused Parameter", "auto logical bitwise compare" and "unused but set parameter" warnings have been fixed.
* CAN receiver masking setting function is missing. Added.